### PR TITLE
fix(file): avoid overflow in the long text base64

### DIFF
--- a/editors/scalar-testing/components/forms/file-form.tsx
+++ b/editors/scalar-testing/components/forms/file-form.tsx
@@ -28,10 +28,7 @@ export function FileForm({ onAddFile, filesState }: FileFormProps) {
 
   return (
     <FormWrapper title="Add File">
-      <div className="flex w-full flex-wrap">
       <State state={filesState} />
-      </div>      
-
       <div className="mb-6">
         <Form
           defaultValues={{ file: null }}

--- a/editors/scalar-testing/components/forms/file-form.tsx
+++ b/editors/scalar-testing/components/forms/file-form.tsx
@@ -28,7 +28,9 @@ export function FileForm({ onAddFile, filesState }: FileFormProps) {
 
   return (
     <FormWrapper title="Add File">
+      <div className="flex w-full flex-wrap">
       <State state={filesState} />
+      </div>      
 
       <div className="mb-6">
         <Form

--- a/editors/scalar-testing/components/state.tsx
+++ b/editors/scalar-testing/components/state.tsx
@@ -13,11 +13,12 @@ export function State<T extends object = ScalarTestingState>({
   return (
     <div className="mb-5">
       <div className="text-sm font-medium">State:</div>
-      {React.createElement(ReactJsonView as any, { 
-        collapsed: true, 
-        enableClipboard: false, 
-        src: state 
-      })}
+        {React.createElement(ReactJsonView as any, {
+          collapsed: true,
+          enableClipboard: false,
+          src: state,
+          style: { wordBreak: "break-word", whiteSpace: "pre-wrap" },
+        })}
     </div>
   );
 }


### PR DESCRIPTION
## Ticket
- https://trello.com/c/bw7e04hI/1077-15-file

## Description
- Avoid that text base64, overflow the container 

Screen Shoot
<img width="1599" height="805" alt="image" src="https://github.com/user-attachments/assets/5fd78fd1-8c75-4d6c-a1fe-4320664c3b18" />
